### PR TITLE
Fix a comment in login template as mail cannot be used as logname

### DIFF
--- a/actdocs/templates/login
+++ b/actdocs/templates/login
@@ -14,7 +14,7 @@
               <div class="col-md-10">
                 <div class="form-group">
                   <label for="form-credential-0">{{Login}}</label>
-                  <input type="text" class="form-control" name="credential_0" id="form-credential-0" placeholder="{{ Specify your login or email address }}">
+                  <input type="text" class="form-control" name="credential_0" id="form-credential-0" placeholder="{{ Specify your login }}">
                 </div>
                 <div class="form-group">
                   <label for="form-credential-1">{{Password}}</label>


### PR DESCRIPTION
The login template suggests that the username can be a mail.
It is wrong and confusing.
And honestly, it is easier to change this comment here than chnaging Act so that email is a valid username.
